### PR TITLE
chore: Update API URL to new scheme

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const request = requestFactory({
   userAgent: true
 })
 
-const baseApiUrl = 'https://nalo.fr/api/v1'
+const baseApiUrl = 'https://api.nalo.fr/api/v1'
 
 module.exports = new BaseKonnector(start)
 


### PR DESCRIPTION
The API URL changed from `https://nalo.fr/api/v1` to `https://api.nalo.fr/api/v1`, update the konnector accordingly